### PR TITLE
Window sizing fix on mode change

### DIFF
--- a/app/main/utils/window.ts
+++ b/app/main/utils/window.ts
@@ -112,8 +112,11 @@ export class Window {
         if (this._window) {
             this.send('window:mode', this.mode);
             this._window.setMinimumSize(this.mins.minWidth, this.mins.minHeight);
+            const bounds = this._window.getBounds();
             if (this.dims) {
                 this._window.setSize(this.dims.width, this.dims.height);
+            } else if (bounds.width < this.mins.minWidth || bounds.height < this.mins.minHeight) {
+                this._window.setSize(this.mins.minWidth, this.mins.minHeight);
             }
         }
     }


### PR DESCRIPTION
Fixes a bug that keeps the window below the minimum size of the target mode if dimensions have not been stored for the target mode. If the dimensions of the target mode do not exist it will try to set the dimensions to the minimum size of the target mode if it is smaller.