### PR TITLE
Adding current working directory to command config

### DIFF
--- a/app/main/services/executor.ts
+++ b/app/main/services/executor.ts
@@ -39,7 +39,7 @@ ipc.on('execute:command', (event: IpcMainEvent, cmdId: string) => {
     if (!cmds || !cmds[cmdId]) { return; }
     const cmd = cmds[cmdId];
     if (!cmd.using || !cmd.using.length) {
-        return runInTerminal(cmd.script, [], { cwd: app.getPath('home') });
+        return runInTerminal(cmd.script, [], { cwd: cmd.cwd || app.getPath('home') });
     } else if (args && cmd.using.filter((argId: string) => !!args[argId]).length) {
         currentId = cmdId;
         global.executorWindow = new Window('executor', 'executor.html', {
@@ -74,7 +74,7 @@ ipc.on('execute:arguments', (_event: IpcMainEvent, values: {[arg: string]: any})
             script = script.replace(rgx, args[argId].context).replace(/<:VALUE:>/g, values[argId]);
         }
     });
-    return runInTerminal(script, [], { cwd: app.getPath('home') });
+    return runInTerminal(script, [], { cwd: cmd.cwd || app.getPath('home') });
 });
 
 ipc.on('execute:cancel', (_event: IpcMainEvent) => {

--- a/app/main/services/file.ts
+++ b/app/main/services/file.ts
@@ -1,5 +1,6 @@
 /** ELECTRON */
 import {
+    app,
     dialog,
     ipcMain as ipc,
     IpcMainEvent,
@@ -21,6 +22,8 @@ ipc.on('fileSync:selectPath', (event: IpcMainEvent, opt?: ISelectOptions) => {
     if (opt) {
         if (opt.start && opt.start.trim()) {
             options.defaultPath = opt.start;
+        } else {
+            options.defaultPath = app.getPath('home');
         }
         if (opt.allowFile) {
             if (typeof options.properties === 'undefined') {

--- a/app/renderer/components/CommandEditor/CommandEditor.hooks.ts
+++ b/app/renderer/components/CommandEditor/CommandEditor.hooks.ts
@@ -4,6 +4,7 @@ import { ICommand } from '../../types';
 /** FIELD HOOKS */
 import {
     useEditorState,
+    useFilePathState,
     useLinkedArgumentsState,
     useTextFieldState,
 } from '../Fields/hooks';
@@ -13,5 +14,6 @@ export const useCommandEditorFieldStates = (command: ICommand) => ({
     label: useTextFieldState(command.label),
     description: useTextFieldState(command.description || ''),
     script: useEditorState(command.script || ''),
+    cwd: useFilePathState(command.cwd || ''),
     using: useLinkedArgumentsState(command.using || []),
 });

--- a/app/renderer/components/CommandEditor/CommandEditor.tsx
+++ b/app/renderer/components/CommandEditor/CommandEditor.tsx
@@ -11,6 +11,7 @@ import Collapse from '@material-ui/core/Collapse';
 
 /** FIELDS */
 import Editor from '../Fields/Editor/Editor';
+import FilePath from '../Fields/FilePath/FilePath';
 import ScriptPreview from '../Fields/ScriptPreview/ScriptPreview';
 import TextField from '../Fields/TextField/TextField';
 
@@ -25,6 +26,7 @@ import { validate } from './CommandEditor.validator';
 
 /** EMPTY COMMAND */
 const EMPTY: ICommand = {
+    cwd: '',
     description: '',
     id: '',
     label: '',
@@ -73,6 +75,14 @@ const CommandEditor: FC = () => {
                     label='Description'
                     help='A description to help understand the purpose of the command'
                     {...fields.description}
+                />
+                <FilePath
+                    label='CWD'
+                    help='The current working directory that the script should run in when executed.'
+                    allowDirectorySelection={true}
+                    allowFileSelection={false}
+                    showHiddenFiles={true}
+                    {...fields.cwd}
                 />
                 <Editor
                     label='Script'

--- a/app/renderer/components/CommandEditor/CommandEditor.validator.ts
+++ b/app/renderer/components/CommandEditor/CommandEditor.validator.ts
@@ -21,6 +21,7 @@ export const validate: CommandEditorValidator = (fields, currentId, allIds) => {
         fields.label.setHasError(true);
     }
     const description = fields.description.value.trim();
+    const cwd = fields.cwd.value;
     const script = fields.script.value;
     if (script.trim() === '') {
         valid = false;
@@ -37,6 +38,7 @@ export const validate: CommandEditorValidator = (fields, currentId, allIds) => {
     const id = currentId || uniqueId(label, allIds);
     return {
         command: {
+            cwd,
             description,
             id,
             label,

--- a/app/renderer/types/_command.types.ts
+++ b/app/renderer/types/_command.types.ts
@@ -8,6 +8,8 @@ export interface ICommand {
     description?: string;
     /** The script to execute */
     script: string;
+    /** Starting point or Current Working Directory of command execution */
+    cwd?: string;
     /** A list of the argument ids that are used by this command */
     using?: string[];
 }


### PR DESCRIPTION
Adds a new field to the command editor that allows the script's cwd to be configured in order to slim the size of the script by removing initial nav commands